### PR TITLE
Add `peer_left` message to signaling server

### DIFF
--- a/signalling_server/README.md
+++ b/signalling_server/README.md
@@ -24,3 +24,11 @@ sock  = new WebSocket("ws://localhost:4000/websocket")
 The `role` field is a role a peer that received info JSON should use to avoid role conflict.
 
 3. Send any message via WS, it will be forwarded to the other side.
+
+4. When a peer leaves, the other one receives JSON message:
+
+```json
+{
+    "type": "peer_left"
+}
+```

--- a/signalling_server/lib/room.ex
+++ b/signalling_server/lib/room.ex
@@ -74,8 +74,16 @@ defmodule SignallingServer.Room do
 
     state =
       if ref == state.p1_ref do
+        if state.p2 do
+          send(state.p2, {:forward, Jason.encode!(%{type: "peer_left"})})
+        end
+
         %{state | p1_ref: nil, p1: nil}
       else
+        if state.p1 do
+          send(state.p1, {:forward, Jason.encode!(%{type: "peer_left"})})
+        end
+
         %{state | p2_ref: nil, p2: nil}
       end
 

--- a/signalling_server/lib/router.ex
+++ b/signalling_server/lib/router.ex
@@ -17,7 +17,7 @@ defmodule SignallingServer.Router do
 
   get "/websocket" do
     conn
-    |> WebSockAdapter.upgrade(SignallingServer.PeerHandler, [], timeout: 2_000)
+    |> WebSockAdapter.upgrade(SignallingServer.PeerHandler, [], [])
     |> halt()
   end
 


### PR DESCRIPTION
It is needed for `ex_webrtc` examples in order to be able to properly close `OggWriter` when peer leaves.