### PR TITLE
Fix issues with not returning state

### DIFF
--- a/lib/ice_agent.ex
+++ b/lib/ice_agent.ex
@@ -1119,6 +1119,8 @@ defmodule ExICE.ICEAgent do
         Not adding srflx candidate as we already have a candidate with the same address.
         Candidate: #{inspect(cand)}
         """)
+
+        state
     end
     |> update_in([:gathering_transactions, t.t_id], fn t -> %{t | state: :complete} end)
   end


### PR DESCRIPTION
State was not returned in one of the `case` arms in `handle_gathering_transaction_success_response` function.

This PR fixes it.