### PR TITLE
Add functions to obtain ICE candidates

### DIFF
--- a/lib/ex_ice/ice_agent.ex
+++ b/lib/ex_ice/ice_agent.ex
@@ -40,7 +40,7 @@ defmodule ExICE.ICEAgent do
            gathering_state_change()
            | connection_state_change()
            | {:data, binary()}
-           | {:new_candidate, binary()}}
+           | {:new_candidate, String.t()}}
 
   @typedoc """
   ICE Agent configuration options.
@@ -120,17 +120,20 @@ defmodule ExICE.ICEAgent do
   end
 
   @doc """
-  Gets local candidates that have been already gathered.
+  Gets all local candidates that have already been gathered.
   """
-  @spec get_local_candidates(pid()) :: [binary()]
+  @spec get_local_candidates(pid()) :: [String.t()]
   def get_local_candidates(ice_agent) do
     GenServer.call(ice_agent, :get_local_candidates)
   end
 
   @doc """
-  Gets remote candidates that have been supplied by `add_remote_candidate/2`.
+  Gets all remote candidates.
+
+  This includes candidates supplied by `add_remote_candidate/2` and candidates
+  discovered during ICE connection establishment process (so called `prflx` candidates).
   """
-  @spec get_remote_candidates(pid()) :: [binary()]
+  @spec get_remote_candidates(pid()) :: [String.t()]
   def get_remote_candidates(ice_agent) do
     GenServer.call(ice_agent, :get_remote_candidates)
   end

--- a/lib/ex_ice/ice_agent.ex
+++ b/lib/ex_ice/ice_agent.ex
@@ -120,6 +120,22 @@ defmodule ExICE.ICEAgent do
   end
 
   @doc """
+  Gets local candidates that have been already gathered.
+  """
+  @spec get_local_candidates(pid()) :: [binary()]
+  def get_local_candidates(ice_agent) do
+    GenServer.call(ice_agent, :get_local_candidates)
+  end
+
+  @doc """
+  Gets remote candidates that have been supplied by `add_remote_candidate/2`.
+  """
+  @spec get_remote_candidates(pid()) :: [binary()]
+  def get_remote_candidates(ice_agent) do
+    GenServer.call(ice_agent, :get_remote_candidates)
+  end
+
+  @doc """
   Sets remote credentials.
 
   Call to this function is mandatory to start connectivity checks.
@@ -254,6 +270,18 @@ defmodule ExICE.ICEAgent do
   def handle_call(:get_local_credentials, _from, state) do
     {local_ufrag, local_pwd} = ICEAgent.Impl.get_local_credentials(state.ice_agent)
     {:reply, {:ok, local_ufrag, local_pwd}, state}
+  end
+
+  @impl true
+  def handle_call(:get_local_candidates, _from, state) do
+    candidates = ICEAgent.Impl.get_local_candidates(state.ice_agent)
+    {:reply, candidates, state}
+  end
+
+  @impl true
+  def handle_call(:get_remote_candidates, _from, state) do
+    candidates = ICEAgent.Impl.get_remote_candidates(state.ice_agent)
+    {:reply, candidates, state}
   end
 
   @impl true

--- a/lib/ex_ice/ice_agent/impl.ex
+++ b/lib/ex_ice/ice_agent/impl.ex
@@ -127,6 +127,16 @@ defmodule ExICE.ICEAgent.Impl do
     {ice_agent.local_ufrag, ice_agent.local_pwd}
   end
 
+  @spec get_local_candidates(t()) :: [binary()]
+  def get_local_candidates(ice_agent) do
+    Enum.map(ice_agent.local_cands, &Candidate.marshal/1)
+  end
+
+  @spec get_remote_candidates(t()) :: [binary()]
+  def get_remote_candidates(ice_agent) do
+    Enum.map(ice_agent.remote_cands, &Candidate.marshal/1)
+  end
+
   @spec get_stats(t()) :: map()
   def get_stats(ice_agent) do
     %{


### PR DESCRIPTION
This PR add `get_local_candidates/1` and `get_remote_candidates/1` functions.