### PR TITLE
Allow to execute gahering transactions when there are no remote credentials

### DIFF
--- a/test/ice_agent/impl_test.exs
+++ b/test/ice_agent/impl_test.exs
@@ -34,6 +34,7 @@ defmodule ExICE.ICEAgent.ImplTest do
 
     test "with correct remote candidate", %{ice_agent: ice_agent} do
       remote_cand = Candidate.new(:host, {192, 168, 0, 2}, 8445, nil, nil, nil)
+      ice_agent = ICEAgent.Impl.set_remote_credentials(ice_agent, "remoteufrag", "remotepwd")
       ice_agent = ICEAgent.Impl.add_remote_candidate(ice_agent, Candidate.marshal(remote_cand))
 
       assert [%Candidate{} = r_cand] = ice_agent.remote_cands


### PR DESCRIPTION
So far, we couldn't execute gathering transactions until we receive remote credentials. 

This is problematic e.g. in WHIP/WHEP where we might not want to use trickle ICE, and instead, send all of our candidates with the SDP offer. 

Adding remote candidates without having remote credentials doesn't make a lot of sense as we can't make any conn checks anyway. On the other cand, by ensuring that we never have remote candidates without remote credentials, we can easily optimize `handle_timeout` function so it will gather srflx candidates.