### PR TITLE
Start mDNS when there is at least 9.1. kernel version

### DIFF
--- a/lib/ex_ice/priv/app.ex
+++ b/lib/ex_ice/priv/app.ex
@@ -2,9 +2,36 @@ defmodule ExICE.Priv.App do
   @moduledoc false
   use Application
 
+  require Logger
+
   @impl true
   def start(_type, _args) do
-    children = [{ExICE.Priv.MDNS.Resolver, :gen_udp}]
+    kernel_ver = kernel_version()
+
+    children =
+      if kernel_ver >= {9, 1} do
+        [{ExICE.Priv.MDNS.Resolver, :gen_udp}]
+      else
+        Logger.warning("""
+        Not starting MDNS resolver as it requires kernel version >= 9.1.
+        Detected kernel version: #{inspect(kernel_ver)}
+        """)
+
+        []
+      end
+
     Supervisor.start_link(children, strategy: :one_for_one)
+  end
+
+  defp kernel_version() do
+    ver =
+      Application.spec(:kernel, :vsn)
+      |> to_string()
+      |> String.split(".")
+
+    major = Enum.at(ver, 0) |> String.to_integer()
+    minor = Enum.at(ver, 1) |> String.to_integer()
+
+    {major, minor}
   end
 end


### PR DESCRIPTION
mDNS relies on REUSEPORT option which was fixed in kernel version 9.1, search for `REUSEPORT` [here](https://erlang.org/download/otp_src_26.1.readme)