### PR TITLE
Timeout pairs after not receiving data for long enough

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Implements:
 * role conflict resolution
 * supports host, prflx, srflx and relay candidates
 * transaction pacing
-* keepalives on valid and selected pairs
+* keepalives (both incoming and outgoing) on valid and selected pairs
 * mDNS client
 
 ## Limitations

--- a/lib/ex_ice/ice_agent.ex
+++ b/lib/ex_ice/ice_agent.ex
@@ -341,7 +341,19 @@ defmodule ExICE.ICEAgent do
 
   @impl true
   def handle_info(:ta_timeout, state) do
-    ice_agent = ExICE.Priv.ICEAgent.handle_timeout(state.ice_agent)
+    ice_agent = ExICE.Priv.ICEAgent.handle_ta_timeout(state.ice_agent)
+    {:noreply, %{state | ice_agent: ice_agent}}
+  end
+
+  @impl true
+  def handle_info(:eoc_timeout, state) do
+    ice_agent = ExICE.Priv.ICEAgent.handle_eoc_timeout(state.ice_agent)
+    {:noreply, %{state | ice_agent: ice_agent}}
+  end
+
+  @impl true
+  def handle_info(:pair_timeout, state) do
+    ice_agent = ExICE.Priv.ICEAgent.handle_pair_timeout(state.ice_agent)
     {:noreply, %{state | ice_agent: ice_agent}}
   end
 

--- a/lib/ex_ice/priv/candidate_pair.ex
+++ b/lib/ex_ice/priv/candidate_pair.ex
@@ -20,7 +20,8 @@ defmodule ExICE.Priv.CandidatePair do
           valid?: boolean,
           succeeded_pair_id: integer() | nil,
           discovered_pair_id: integer() | nil,
-          keepalive_timer: reference() | nil
+          keepalive_timer: reference() | nil,
+          last_seen: integer()
         }
 
   @enforce_keys [:id, :local_cand_id, :remote_cand_id, :priority]
@@ -32,7 +33,10 @@ defmodule ExICE.Priv.CandidatePair do
                 valid?: false,
                 succeeded_pair_id: nil,
                 discovered_pair_id: nil,
-                keepalive_timer: nil
+                keepalive_timer: nil,
+                # Time when this pair has received some data
+                # or sent conn check.
+                last_seen: nil
               ]
 
   @doc false
@@ -47,7 +51,8 @@ defmodule ExICE.Priv.CandidatePair do
       remote_cand_id: remote_cand.id,
       priority: priority,
       state: state,
-      valid?: opts[:valid?] || false
+      valid?: opts[:valid?] || false,
+      last_seen: opts[:last_seen]
     }
   end
 

--- a/lib/ex_ice/priv/ice_agent.ex
+++ b/lib/ex_ice/priv/ice_agent.ex
@@ -506,9 +506,11 @@ defmodule ExICE.Priv.ICEAgent do
   end
 
   defp timeout_pairs(ice_agent, [pair | pairs], now) do
-    if now - pair.last_seen >= @pair_timeout do
+    diff = now - pair.last_seen
+
+    if diff >= @pair_timeout do
       Logger.debug("""
-      Pair: #{pair.id} didn't receive any data in #{@pair_timeout}ms. \
+      Pair: #{pair.id} didn't receive any data in #{diff}ms. \
       Marking as failed.\
       """)
 


### PR DESCRIPTION
This PR:
* timeouts pairs if they don't receive any data for long enough (5 seconds)
* sets end-of-candidates flag after 10 seconds (this is chosen arbitrarly) starting from calling `set_remote_credentials` (see [RFC 8863](https://datatracker.ietf.org/doc/html/rfc8863#section-4-2))
* converts selected_pair into selected_pair_id
* renames `handle_timeout` to `handle_ta_timeout`