### PR TITLE
Handle non matching family for ips, invalid TURN uri errors

### DIFF
--- a/lib/ex_ice/priv/ice_agent.ex
+++ b/lib/ex_ice/priv/ice_agent.ex
@@ -876,6 +876,14 @@ defmodule ExICE.Priv.ICEAgent do
         }
 
         {t_id, t}
+      else
+        false ->
+          Logger.warning("Client's IP family doesn't match the socket's IP family. Ignoring.")
+          {nil, nil}
+
+        other ->
+          Logger.warning("Couldn't create TURN client: #{inspect(other)}. Ignoring.")
+          {nil, nil}
       end
     end
     |> Enum.reject(fn {tr_id, tr} -> tr_id == nil and tr == nil end)

--- a/lib/ex_ice/priv/ice_agent.ex
+++ b/lib/ex_ice/priv/ice_agent.ex
@@ -864,7 +864,8 @@ defmodule ExICE.Priv.ICEAgent do
       with {:ok, client} <-
              ExTURN.Client.new(turn_server.url, turn_server.username, turn_server.credential),
            {:ok, {sock_ip, _sock_port}} <- ice_agent.transport_module.sockname(socket),
-           true <- Utils.family(client.turn_ip) == Utils.family(sock_ip) do
+           {true, _, _} <-
+             {Utils.family(client.turn_ip) == Utils.family(sock_ip), client, sock_ip} do
         t_id = {socket, {client.turn_ip, client.turn_port}}
 
         t = %{
@@ -877,8 +878,11 @@ defmodule ExICE.Priv.ICEAgent do
 
         {t_id, t}
       else
-        false ->
-          Logger.warning("Client's IP family doesn't match the socket's IP family. Ignoring.")
+        {false, client, sock_ip} ->
+          Logger.warning(
+            "Client's IP family doesn't match the socket's IP family (Client IP: #{inspect(client.turn_ip)} vs Socket IP: #{inspect(sock_ip)}). Ignoring."
+          )
+
           {nil, nil}
 
         other ->

--- a/test/priv/ice_agent_test.exs
+++ b/test/priv/ice_agent_test.exs
@@ -68,6 +68,38 @@ defmodule ExICE.Priv.ICEAgentTest do
     end
   end
 
+  describe "gather_candidates/1" do
+    setup do
+      ice_agent =
+        ICEAgent.new(
+          gathering_state: :new,
+          ice_transport_policy: :all,
+          controlling_process: self(),
+          role: :controlling,
+          if_discovery_module: IfDiscovery.Mock,
+          transport_module: Transport.Mock
+        )
+
+      %{ice_agent: ice_agent}
+    end
+
+    test ~c"Agent with invalid TURN server url doesn't raise an exception", %{
+      ice_agent: ice_agent
+    } do
+      assert %ICEAgent{gathering_state: :complete} =
+               ICEAgent.gather_candidates(%{
+                 ice_agent
+                 | turn_servers: [
+                     %{
+                       url: "invalid.turn.url",
+                       username: "user",
+                       credential: "pass"
+                     }
+                   ]
+               })
+    end
+  end
+
   describe "add_remote_candidate/2" do
     setup do
       ice_agent =

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,3 @@
 ExICE.Support.Transport.Mock.init()
 
-ExUnit.start(capture_log: true, exclude: [:relay])
+ExUnit.start(capture_log: true, exclude: [])

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,3 @@
 ExICE.Support.Transport.Mock.init()
 
-ExUnit.start(capture_log: true, exclude: [])
+ExUnit.start(capture_log: true, exclude: [:relay])


### PR DESCRIPTION
When using `ex_ice` library as part of `ex_webrtc` library we would like to use custom Coturn server for ICE communication. While testing, we got exceptions raised in the `create_relay_gathering_transactions/3` function. It's getting raised when client TURN ip family doesn't match to Socket ip family (IPv4 vs IPv6). Should we handle it in the library and skip those relay gathering transactions?

PS: this PR also fixes https://github.com/elixir-webrtc/ex_ice/blob/master/test/integration/p2p_test.exs#L128 test.

PPS: I'll provide our Coturn config soon.

Let me know if this PR make sense, or we need to use `ex_webrtc`/`ex_ice` in other way, thanks in advance!

Fixes #59 