### PR TITLE
Include related address and port in marshaled candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ as WebRTC multiplexes traffic on a single socket but PRs are welcomed
 ```elixir
 def deps do
   [
-    {:ex_ice, "~> 0.8.1"}
+    {:ex_ice, "~> 0.8.2"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExICE.MixProject do
   use Mix.Project
 
-  @version "0.8.1"
+  @version "0.8.2"
   @source_url "https://github.com/elixir-webrtc/ex_ice"
 
   def project do


### PR DESCRIPTION
Firefox (and RFC too) requires rel-addr and rel-port for reflexive candidates to be present.  This is described in [RFC 8839 sec. 5.1](https://www.rfc-editor.org/rfc/rfc8839.html#section-5.1-4.16). For security reasons, i.e. not to leak private address, we always use 0.0.0.0 (or ::) and 9.


The error thrown by Firefox when there is no rel-addr and rel-port:

```
ICE(PC:{8fb57bb0-1673-4214-8fb8-0f32d8770df5} 1726653687536093 (id=6442450945 url=https://nexus-crimson-sea-2293.fly.dev/)): Error parsing attribute: candidate:1970122717 1 UDP 1694498815 217.30.x.x 34733 typ srflx
```