### PR TITLE
Pair newly gathered host candidates with existing remote candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ as WebRTC multiplexes traffic on a single socket but PRs are welcomed
 ```elixir
 def deps do
   [
-    {:ex_ice, "~> 0.9.2"}
+    {:ex_ice, "~> 0.9.3"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExICE.MixProject do
   use Mix.Project
 
-  @version "0.9.2"
+  @version "0.9.3"
   @source_url "https://github.com/elixir-webrtc/ex_ice"
 
   def project do


### PR DESCRIPTION
It might happen that remote candidates are added before `gather_candidates/1` is called (consider an offer that contains ICE candidates, which is common in WHIP/WHEP). When `gather_candidates/1` is finally called we won't pair newly gather host candidates with already exisiting remote candidates.

This PR ensures that after gathering host candidate, it is paired with existing remote candidates. 