### PR TITLE
Don't clear entire state after moving to the failed or completed state

### DIFF
--- a/lib/ex_ice/priv/candidate_base.ex
+++ b/lib/ex_ice/priv/candidate_base.ex
@@ -13,7 +13,8 @@ defmodule ExICE.Priv.CandidateBase do
           transport: :udp,
           transport_module: module(),
           socket: :inet.socket() | nil,
-          type: Candidate.type()
+          type: Candidate.type(),
+          closed?: boolean()
         }
 
   @derive {Inspect, except: [:socket]}
@@ -27,7 +28,7 @@ defmodule ExICE.Priv.CandidateBase do
     :transport_module,
     :type
   ]
-  defstruct @enforce_keys ++ [:base_address, :base_port, :socket]
+  defstruct @enforce_keys ++ [:base_address, :base_port, :socket, closed?: false]
 
   @spec new(Candidate.type(), Keyword.t()) :: t()
   def new(type, config) do

--- a/lib/ex_ice/priv/conn_check_handler/controlling.ex
+++ b/lib/ex_ice/priv/conn_check_handler/controlling.ex
@@ -27,22 +27,42 @@ defmodule ExICE.Priv.ConnCheckHandler.Controlling do
   def handle_conn_check_request(ice_agent, pair, msg, nil) do
     # TODO use triggered check queue
     case Checklist.find_pair(ice_agent.checklist, pair) do
-      nil ->
+      nil when ice_agent.state in [:completed, :failed] ->
+        Logger.warning("""
+        Received conn check request for non-existing pair in unexpected state: #{ice_agent.state}. Ignoring\
+        """)
+
+        ice_agent
+
+      nil when ice_agent.state in [:new, :checking, :connected] ->
         Logger.debug("Adding new candidate pair: #{inspect(pair)}")
         checklist = Map.put(ice_agent.checklist, pair.id, pair)
         ice_agent = %ICEAgent{ice_agent | checklist: checklist}
         ICEAgent.send_binding_success_response(ice_agent, pair, msg)
 
       %CandidatePair{} = checklist_pair ->
-        checklist_pair =
-          if checklist_pair.state == :failed do
-            %CandidatePair{checklist_pair | state: :waiting, last_seen: pair.last_seen}
-          else
-            %CandidatePair{checklist_pair | last_seen: pair.last_seen}
-          end
+        cond do
+          checklist_pair.state == :failed and ice_agent.state in [:failed, :completed] ->
+            # update last seen so we can observe that something is received but don't reply
+            # as we are in the failed state
+            checklist_pair = %CandidatePair{checklist_pair | last_seen: pair.last_seen}
+            put_in(ice_agent.checklist[checklist_pair.id], checklist_pair)
 
-        ice_agent = put_in(ice_agent.checklist[checklist_pair.id], checklist_pair)
-        ICEAgent.send_binding_success_response(ice_agent, checklist_pair, msg)
+          checklist_pair.state == :failed ->
+            checklist_pair = %CandidatePair{
+              checklist_pair
+              | state: :waiting,
+                last_seen: pair.last_seen
+            }
+
+            ice_agent = put_in(ice_agent.checklist[checklist_pair.id], checklist_pair)
+            ICEAgent.send_binding_success_response(ice_agent, checklist_pair, msg)
+
+          true ->
+            checklist_pair = %CandidatePair{checklist_pair | last_seen: pair.last_seen}
+            ice_agent = put_in(ice_agent.checklist[checklist_pair.id], checklist_pair)
+            ICEAgent.send_binding_success_response(ice_agent, checklist_pair, msg)
+        end
     end
   end
 

--- a/test/priv/conn_check_handler/controlled_test.exs
+++ b/test/priv/conn_check_handler/controlled_test.exs
@@ -1,0 +1,365 @@
+defmodule ExICE.Priv.ConnCheckHandler.ControlledTest do
+  use ExUnit.Case, async: true
+
+  alias ExICE.Priv.ICEAgent
+  alias ExICE.Priv.Attribute.{ICEControlled, ICEControlling, Priority, UseCandidate}
+  alias ExICE.Priv.ConnCheckHandler.Controlled
+  alias ExICE.Support.Transport
+
+  alias ExSTUN.Message
+  alias ExSTUN.Message.Type
+  alias ExSTUN.Message.Attribute.Username
+
+  defmodule IfDiscovery.Mock do
+    @behaviour ExICE.Priv.IfDiscovery
+
+    @impl true
+    def getifaddrs() do
+      ifs = [{~c"mockif", [{:flags, [:up, :running]}, {:addr, {192, 168, 0, 1}}]}]
+      {:ok, ifs}
+    end
+  end
+
+  @remote_cand ExICE.Candidate.new(:host, address: {192, 168, 0, 2}, port: 8445)
+  @remote_cand2 ExICE.Candidate.new(:host, address: {192, 168, 0, 3}, port: 8445)
+
+  describe "incoming binding request" do
+    setup do
+      ice_agent =
+        ICEAgent.new(
+          controlling_process: self(),
+          role: :controlled,
+          transport_module: Transport.Mock,
+          if_discovery_module: IfDiscovery.Mock
+        )
+        |> ICEAgent.set_remote_credentials("someufrag", "somepwd")
+        |> ICEAgent.gather_candidates()
+
+      req =
+        binding_request(
+          ice_agent.role,
+          ice_agent.tiebreaker,
+          "somepwd",
+          ice_agent.local_ufrag,
+          ice_agent.local_pwd
+        )
+
+      use_c_req =
+        binding_request(
+          ice_agent.role,
+          ice_agent.tiebreaker,
+          "somepwd",
+          ice_agent.local_ufrag,
+          ice_agent.local_pwd,
+          true
+        )
+
+      %{ice_agent: ice_agent, req: req, use_c_req: use_c_req}
+    end
+
+    test "on failed pair in failed state", %{ice_agent: ice_agent, req: req, use_c_req: use_c_req} do
+      ice_agent = ICEAgent.add_remote_candidate(ice_agent, @remote_cand)
+
+      # set pair and agent states to failed
+      [pair_id] = Map.keys(ice_agent.checklist)
+      ice_agent = put_in(ice_agent.checklist[pair_id].state, :failed)
+      ice_agent = %{ice_agent | state: :failed}
+
+      # try to handle binding request
+      [socket] = ice_agent.sockets
+      pair = Map.fetch!(ice_agent.checklist, pair_id)
+      new_ice_agent = Controlled.handle_conn_check_request(ice_agent, pair, req, nil)
+
+      # assert a response has not been sent, and pair and agent are still in state failed
+      pair = Map.fetch!(new_ice_agent.checklist, pair_id)
+      assert Transport.Mock.recv(socket) == nil
+      assert new_ice_agent.state == :failed
+      assert pair.state == :failed
+
+      # the same when with UseCandidate flag
+      new_ice_agent =
+        Controlled.handle_conn_check_request(ice_agent, pair, use_c_req, %UseCandidate{})
+
+      # assert a response has not been sent, and pair and agent are still in state failed
+      pair = Map.fetch!(new_ice_agent.checklist, pair_id)
+      assert Transport.Mock.recv(socket) == nil
+      assert new_ice_agent.state == :failed
+      assert pair.state == :failed
+    end
+
+    test "on failed pair in completed state", %{
+      ice_agent: ice_agent,
+      req: req,
+      use_c_req: use_c_req
+    } do
+      ice_agent = ICEAgent.add_remote_candidate(ice_agent, @remote_cand)
+      ice_agent = ICEAgent.add_remote_candidate(ice_agent, @remote_cand2)
+
+      # set pair and agent states
+      [pair_id1, pair_id2] = Map.keys(ice_agent.checklist)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].state, :failed)
+      ice_agent = put_in(ice_agent.checklist[pair_id2].state, :succeeded)
+      ice_agent = put_in(ice_agent.checklist[pair_id2].valid?, true)
+      ice_agent = put_in(ice_agent.selected_pair_id, pair_id2)
+      ice_agent = %{ice_agent | state: :completed}
+
+      # try to handle binding request
+      [socket] = ice_agent.sockets
+      pair1 = Map.fetch!(ice_agent.checklist, pair_id1)
+      new_ice_agent = Controlled.handle_conn_check_request(ice_agent, pair1, req, nil)
+
+      # assert a response has not been sent, pair_id1 is still in state failed and agent is still in state completed
+      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      assert Transport.Mock.recv(socket) == nil
+      assert new_ice_agent.state == :completed
+      assert pair1.state == :failed
+
+      # the same when with UseCandidate flag
+      new_ice_agent =
+        Controlled.handle_conn_check_request(ice_agent, pair1, use_c_req, %UseCandidate{})
+
+      # assert a response has not been sent, pair_id1 is still in state failed and agent is still in state completed
+      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      assert Transport.Mock.recv(socket) == nil
+      assert new_ice_agent.state == :completed
+      assert pair1.state == :failed
+    end
+
+    test "on failed pair in connected state", %{
+      ice_agent: ice_agent,
+      req: req,
+      use_c_req: use_c_req
+    } do
+      ice_agent = ICEAgent.add_remote_candidate(ice_agent, @remote_cand)
+      ice_agent = ICEAgent.add_remote_candidate(ice_agent, @remote_cand2)
+
+      # set pair and agent states
+      [pair_id1, pair_id2] = Map.keys(ice_agent.checklist)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].state, :failed)
+      ice_agent = put_in(ice_agent.checklist[pair_id2].state, :succeeded)
+      ice_agent = put_in(ice_agent.checklist[pair_id2].valid?, true)
+      ice_agent = %{ice_agent | state: :connected}
+
+      # try to handle binding request
+      [socket] = ice_agent.sockets
+      pair1 = Map.fetch!(ice_agent.checklist, pair_id1)
+      new_ice_agent = Controlled.handle_conn_check_request(ice_agent, pair1, req, nil)
+
+      # assert a response has been sent, pair_id1 is waiting and agent is connected
+      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      assert Transport.Mock.recv(socket) != nil
+      assert new_ice_agent.state == :connected
+      assert pair1.state == :waiting
+      assert pair1.nominate? == false
+
+      # the same when with UseCandidate flag
+      new_ice_agent =
+        Controlled.handle_conn_check_request(ice_agent, pair1, use_c_req, %UseCandidate{})
+
+      # assert a response has been sent, pair is waiting and agent is connected
+      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      assert Transport.Mock.recv(socket) != nil
+      assert new_ice_agent.state == :connected
+      assert pair1.state == :waiting
+      assert pair1.nominate? == true
+    end
+
+    test "on selected pair in completed state", %{
+      ice_agent: ice_agent,
+      req: req,
+      use_c_req: use_c_req
+    } do
+      ice_agent = ICEAgent.add_remote_candidate(ice_agent, @remote_cand)
+
+      # set pair and agent states
+      [pair_id1] = Map.keys(ice_agent.checklist)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].state, :succeeded)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].valid?, true)
+      # That's a little hack as we are mocking a lot of things.
+      # To avoid it, we would have to go through the full req/resp flow using handle_udp function.
+      ice_agent = put_in(ice_agent.checklist[pair_id1].discovered_pair_id, pair_id1)
+
+      ice_agent = put_in(ice_agent.selected_pair_id, pair_id1)
+      ice_agent = %{ice_agent | state: :completed}
+
+      # try to handle binding request
+      [socket] = ice_agent.sockets
+      pair1 = Map.fetch!(ice_agent.checklist, pair_id1)
+      new_ice_agent = Controlled.handle_conn_check_request(ice_agent, pair1, req, nil)
+
+      # assert a response has been sent, pair_id1 is still in state succeeded and agent is still in state completed
+      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      assert Transport.Mock.recv(socket) != nil
+      assert new_ice_agent.state == :completed
+      assert new_ice_agent.selected_pair_id == pair_id1
+      assert pair1.state == :succeeded
+      assert pair1.valid? == true
+
+      # the same when with UseCandidate flag
+      new_ice_agent =
+        Controlled.handle_conn_check_request(ice_agent, pair1, use_c_req, %UseCandidate{})
+
+      # assert a response has not been sent, pair_id1 is still in state failed and agent is still in state completed
+      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      assert Transport.Mock.recv(socket) != nil
+      assert new_ice_agent.state == :completed
+      assert new_ice_agent.selected_pair_id == pair_id1
+      assert pair1.state == :succeeded
+      assert pair1.valid? == true
+    end
+
+    test "on succeeded pair in connected state", %{
+      ice_agent: ice_agent,
+      req: req,
+      use_c_req: use_c_req
+    } do
+      ice_agent = ICEAgent.add_remote_candidate(ice_agent, @remote_cand)
+
+      # set pair and agent states
+      [pair_id1] = Map.keys(ice_agent.checklist)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].state, :succeeded)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].valid?, true)
+      # That's a little hack as we are mocking a lot of things.
+      # To avoid it, we would have to go through the full req/resp flow using handle_udp function.
+      ice_agent = put_in(ice_agent.checklist[pair_id1].discovered_pair_id, pair_id1)
+      ice_agent = %{ice_agent | state: :connected}
+
+      # try to handle binding request
+      [socket] = ice_agent.sockets
+      pair1 = Map.fetch!(ice_agent.checklist, pair_id1)
+      new_ice_agent = Controlled.handle_conn_check_request(ice_agent, pair1, req, nil)
+
+      # assert a response has been sent, pair_id1 is still in state succeeded and agent is still in state connected
+      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      assert Transport.Mock.recv(socket) != nil
+      assert new_ice_agent.state == :connected
+      assert new_ice_agent.selected_pair_id == nil
+      assert pair1.state == :succeeded
+      assert pair1.valid? == true
+
+      # the same when with UseCandidate flag
+      new_ice_agent =
+        Controlled.handle_conn_check_request(ice_agent, pair1, use_c_req, %UseCandidate{})
+
+      # assert a response has been sent, pair_id1 is still in state succeeded, agent is still in state connected but there is also selected pair
+      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      assert Transport.Mock.recv(socket) != nil
+      assert new_ice_agent.state == :connected
+      assert new_ice_agent.selected_pair_id == pair_id1
+      assert pair1.state == :succeeded
+      assert pair1.valid? == true
+    end
+
+    test "on succeeded pair that has higher prio in connected state", %{
+      ice_agent: ice_agent,
+      use_c_req: use_c_req
+    } do
+      ice_agent = ICEAgent.add_remote_candidate(ice_agent, @remote_cand)
+      ice_agent = ICEAgent.add_remote_candidate(ice_agent, @remote_cand2)
+
+      # set pair and agent states
+      [pair_id1, pair_id2] = Map.keys(ice_agent.checklist)
+      pair2 = Map.fetch!(ice_agent.checklist, pair_id2)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].state, :succeeded)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].priority, pair2.priority + 1)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].valid?, true)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].discovered_pair_id, pair_id1)
+      ice_agent = put_in(ice_agent.checklist[pair_id2].state, :succeeded)
+      ice_agent = put_in(ice_agent.checklist[pair_id2].valid?, true)
+      ice_agent = put_in(ice_agent.checklist[pair_id2].discovered_pair_id, pair_id2)
+      ice_agent = put_in(ice_agent.selected_pair_id, pair_id2)
+      ice_agent = %{ice_agent | state: :connected}
+
+      # try to handle binding request
+      [socket] = ice_agent.sockets
+      pair1 = Map.fetch!(ice_agent.checklist, pair_id1)
+
+      new_ice_agent =
+        Controlled.handle_conn_check_request(ice_agent, pair1, use_c_req, %UseCandidate{})
+
+      # assert a response has been sent, and pair_id1 is a new selected pair
+      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      assert Transport.Mock.recv(socket) != nil
+      assert new_ice_agent.state == :connected
+      assert new_ice_agent.selected_pair_id == pair_id1
+      assert pair1.state == :succeeded
+      assert pair1.valid? == true
+    end
+
+    test "on unknown pair in connected state", %{
+      ice_agent: ice_agent,
+      req: req,
+      use_c_req: use_c_req
+    } do
+      ice_agent = ICEAgent.add_remote_candidate(ice_agent, @remote_cand)
+      ice_agent = ICEAgent.add_remote_candidate(ice_agent, @remote_cand2)
+
+      # set pair and agent states
+      [pair_id1, pair_id2] = Map.keys(ice_agent.checklist)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].state, :succeeded)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].valid?, true)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].discovered_pair_id, pair_id1)
+      ice_agent = %{ice_agent | state: :connected}
+
+      # Pop pair2 so it's not in the checklist but its remote candidate is already in ice state
+      # that's a little hack as we omit handle_udp, which is responsible for adding prflx candidate to the state.
+      # In other case, we wouldn't be able to send success response.
+      {pair2, ice_agent} = pop_in(ice_agent.checklist[pair_id2])
+
+      # try to handle binding request from unknown pair
+      [socket] = ice_agent.sockets
+      new_ice_agent = Controlled.handle_conn_check_request(ice_agent, pair2, req, nil)
+
+      # assert a response has been sent, and we have a new pair in the checklist
+      pair2 = Map.fetch!(new_ice_agent.checklist, pair_id2)
+      assert Transport.Mock.recv(socket) != nil
+      assert new_ice_agent.state == :connected
+      assert pair2.state == :waiting
+      assert pair2.valid? == false
+      assert pair2.nominate? == false
+
+      # the same with UseCandidate flag
+      new_ice_agent =
+        Controlled.handle_conn_check_request(ice_agent, pair2, use_c_req, %UseCandidate{})
+
+      # assert a response has been sent, and we have a new pair in the checklist
+      pair2 = Map.fetch!(new_ice_agent.checklist, pair_id2)
+      assert Transport.Mock.recv(socket) != nil
+      assert new_ice_agent.state == :connected
+      assert pair2.state == :waiting
+      assert pair2.valid? == false
+      assert pair2.nominate? == true
+    end
+
+    defp binding_request(
+           role,
+           tiebreaker,
+           local_ufrag,
+           remote_ufrag,
+           remote_pwd,
+           use_candidate \\ false
+         ) do
+      ice_attrs =
+        cond do
+          role == :controlled and use_candidate == true ->
+            [%ICEControlling{tiebreaker: tiebreaker + 1}, %UseCandidate{}]
+
+          role == :controlled and use_candidate == false ->
+            [%ICEControlling{tiebreaker: tiebreaker + 1}]
+
+          role == :controlling ->
+            [%ICEControlled{tiebreaker: tiebreaker - 1}]
+        end
+
+      attrs =
+        [
+          %Username{value: "#{remote_ufrag}:#{local_ufrag}"},
+          %Priority{priority: 1234}
+        ] ++ ice_attrs
+
+      Message.new(%Type{class: :request, method: :binding}, attrs)
+      |> Message.with_integrity(remote_pwd)
+      |> Message.with_fingerprint()
+    end
+  end
+end

--- a/test/priv/conn_check_handler/controlling_test.exs
+++ b/test/priv/conn_check_handler/controlling_test.exs
@@ -1,0 +1,243 @@
+defmodule ExICE.Priv.ConnCheckHandler.ControllingTest do
+  use ExUnit.Case, async: true
+
+  alias ExICE.Priv.ICEAgent
+  alias ExICE.Priv.Attribute.{ICEControlled, ICEControlling, Priority, UseCandidate}
+  alias ExICE.Priv.ConnCheckHandler.Controlling
+  alias ExICE.Support.Transport
+
+  alias ExSTUN.Message
+  alias ExSTUN.Message.Type
+  alias ExSTUN.Message.Attribute.Username
+
+  defmodule IfDiscovery.Mock do
+    @behaviour ExICE.Priv.IfDiscovery
+
+    @impl true
+    def getifaddrs() do
+      ifs = [{~c"mockif", [{:flags, [:up, :running]}, {:addr, {192, 168, 0, 1}}]}]
+      {:ok, ifs}
+    end
+  end
+
+  @remote_cand ExICE.Candidate.new(:host, address: {192, 168, 0, 2}, port: 8445)
+  @remote_cand2 ExICE.Candidate.new(:host, address: {192, 168, 0, 3}, port: 8445)
+
+  describe "incoming binding request" do
+    setup do
+      ice_agent =
+        ICEAgent.new(
+          controlling_process: self(),
+          role: :controlling,
+          transport_module: Transport.Mock,
+          if_discovery_module: IfDiscovery.Mock
+        )
+        |> ICEAgent.set_remote_credentials("someufrag", "somepwd")
+        |> ICEAgent.gather_candidates()
+
+      req =
+        binding_request(
+          ice_agent.role,
+          ice_agent.tiebreaker,
+          "somepwd",
+          ice_agent.local_ufrag,
+          ice_agent.local_pwd
+        )
+
+      use_c_req =
+        binding_request(
+          ice_agent.role,
+          ice_agent.tiebreaker,
+          "somepwd",
+          ice_agent.local_ufrag,
+          ice_agent.local_pwd,
+          true
+        )
+
+      %{ice_agent: ice_agent, req: req, use_c_req: use_c_req}
+    end
+
+    test "with UseCandidate flag", %{ice_agent: ice_agent, use_c_req: use_c_req} do
+      ice_agent = ICEAgent.add_remote_candidate(ice_agent, @remote_cand)
+
+      # set pair and agent states to failed
+      [pair_id] = Map.keys(ice_agent.checklist)
+
+      # try to handle binding request
+      [socket] = ice_agent.sockets
+      pair = Map.fetch!(ice_agent.checklist, pair_id)
+
+      new_ice_agent =
+        Controlling.handle_conn_check_request(ice_agent, pair, use_c_req, %UseCandidate{})
+
+      # assert error response has been sent, and pair and agent have the same state
+      new_pair = Map.fetch!(new_ice_agent.checklist, pair_id)
+      assert resp = Transport.Mock.recv(socket)
+      assert {:ok, %{type: %{class: :error_response}}} = ExSTUN.Message.decode(resp)
+      assert new_ice_agent.state == ice_agent.state
+      assert new_pair.state == pair.state
+    end
+
+    test "on failed pair in completed state", %{ice_agent: ice_agent, req: req} do
+      ice_agent = ICEAgent.add_remote_candidate(ice_agent, @remote_cand)
+      ice_agent = ICEAgent.add_remote_candidate(ice_agent, @remote_cand2)
+
+      # set pair and agent states
+      [pair_id1, pair_id2] = Map.keys(ice_agent.checklist)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].state, :failed)
+      ice_agent = put_in(ice_agent.checklist[pair_id2].state, :succeeded)
+      ice_agent = put_in(ice_agent.checklist[pair_id2].valid?, true)
+      ice_agent = put_in(ice_agent.selected_pair_id, pair_id2)
+      ice_agent = %{ice_agent | state: :completed}
+
+      # try to handle binding request
+      [socket] = ice_agent.sockets
+      pair1 = Map.fetch!(ice_agent.checklist, pair_id1)
+      new_ice_agent = Controlling.handle_conn_check_request(ice_agent, pair1, req, nil)
+
+      # assert a response has not been sent, pair_id1 is still in state failed and agent is still in state completed
+      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      assert Transport.Mock.recv(socket) == nil
+      assert new_ice_agent.state == :completed
+      assert pair1.state == :failed
+    end
+
+    test "on failed pair in connected state", %{ice_agent: ice_agent, req: req} do
+      ice_agent = ICEAgent.add_remote_candidate(ice_agent, @remote_cand)
+      ice_agent = ICEAgent.add_remote_candidate(ice_agent, @remote_cand2)
+
+      # set pair and agent states
+      [pair_id1, pair_id2] = Map.keys(ice_agent.checklist)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].state, :failed)
+      ice_agent = put_in(ice_agent.checklist[pair_id2].state, :succeeded)
+      ice_agent = put_in(ice_agent.checklist[pair_id2].valid?, true)
+      ice_agent = %{ice_agent | state: :connected}
+
+      # try to handle binding request
+      [socket] = ice_agent.sockets
+      pair1 = Map.fetch!(ice_agent.checklist, pair_id1)
+      new_ice_agent = Controlling.handle_conn_check_request(ice_agent, pair1, req, nil)
+
+      # assert a response has been sent, pair_id1 is waiting and agent is connected
+      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      assert Transport.Mock.recv(socket) != nil
+      assert new_ice_agent.state == :connected
+      assert pair1.state == :waiting
+      assert pair1.nominate? == false
+    end
+
+    test "on selected pair in completed state", %{ice_agent: ice_agent, req: req} do
+      ice_agent = ICEAgent.add_remote_candidate(ice_agent, @remote_cand)
+
+      # set pair and agent states
+      [pair_id1] = Map.keys(ice_agent.checklist)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].state, :succeeded)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].valid?, true)
+      # That's a little hack as we are mocking a lot of things.
+      # To avoid it, we would have to go through the full req/resp flow using handle_udp function.
+      ice_agent = put_in(ice_agent.checklist[pair_id1].discovered_pair_id, pair_id1)
+
+      ice_agent = put_in(ice_agent.selected_pair_id, pair_id1)
+      ice_agent = %{ice_agent | state: :completed}
+
+      # try to handle binding request
+      [socket] = ice_agent.sockets
+      pair1 = Map.fetch!(ice_agent.checklist, pair_id1)
+      new_ice_agent = Controlling.handle_conn_check_request(ice_agent, pair1, req, nil)
+
+      # assert a response has been sent, pair_id1 is still in state succeeded and agent is still in state completed
+      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      assert Transport.Mock.recv(socket) != nil
+      assert new_ice_agent.state == :completed
+      assert new_ice_agent.selected_pair_id == pair_id1
+      assert pair1.state == :succeeded
+      assert pair1.valid? == true
+    end
+
+    test "on succeeded pair in connected state", %{ice_agent: ice_agent, req: req} do
+      ice_agent = ICEAgent.add_remote_candidate(ice_agent, @remote_cand)
+
+      # set pair and agent states
+      [pair_id1] = Map.keys(ice_agent.checklist)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].state, :succeeded)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].valid?, true)
+      # That's a little hack as we are mocking a lot of things.
+      # To avoid it, we would have to go through the full req/resp flow using handle_udp function.
+      ice_agent = put_in(ice_agent.checklist[pair_id1].discovered_pair_id, pair_id1)
+      ice_agent = %{ice_agent | state: :connected}
+
+      # try to handle binding request
+      [socket] = ice_agent.sockets
+      pair1 = Map.fetch!(ice_agent.checklist, pair_id1)
+      new_ice_agent = Controlling.handle_conn_check_request(ice_agent, pair1, req, nil)
+
+      # assert a response has been sent, pair_id1 is still in state succeeded and agent is still in state connected
+      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      assert Transport.Mock.recv(socket) != nil
+      assert new_ice_agent.state == :connected
+      assert new_ice_agent.selected_pair_id == nil
+      assert pair1.state == :succeeded
+      assert pair1.valid? == true
+    end
+
+    test "on unknown pair in connected state", %{ice_agent: ice_agent, req: req} do
+      ice_agent = ICEAgent.add_remote_candidate(ice_agent, @remote_cand)
+      ice_agent = ICEAgent.add_remote_candidate(ice_agent, @remote_cand2)
+
+      # set pair and agent states
+      [pair_id1, pair_id2] = Map.keys(ice_agent.checklist)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].state, :succeeded)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].valid?, true)
+      ice_agent = put_in(ice_agent.checklist[pair_id1].discovered_pair_id, pair_id1)
+      ice_agent = %{ice_agent | state: :connected}
+
+      # Pop pair2 so it's not in the checklist but its remote candidate is already in ice state
+      # that's a little hack as we omit handle_udp, which is responsible for adding prflx candidate to the state.
+      # In other case, we wouldn't be able to send success response.
+      {pair2, ice_agent} = pop_in(ice_agent.checklist[pair_id2])
+
+      # try to handle binding request from unknown pair
+      [socket] = ice_agent.sockets
+      new_ice_agent = Controlling.handle_conn_check_request(ice_agent, pair2, req, nil)
+
+      # assert a response has been sent, and we have a new pair in the checklist
+      pair2 = Map.fetch!(new_ice_agent.checklist, pair_id2)
+      assert Transport.Mock.recv(socket) != nil
+      assert new_ice_agent.state == :connected
+      assert pair2.state == :waiting
+      assert pair2.valid? == false
+      assert pair2.nominate? == false
+    end
+
+    defp binding_request(
+           role,
+           tiebreaker,
+           local_ufrag,
+           remote_ufrag,
+           remote_pwd,
+           use_candidate \\ false
+         ) do
+      ice_attrs =
+        cond do
+          role == :controlled and use_candidate == true ->
+            [%ICEControlling{tiebreaker: tiebreaker + 1}, %UseCandidate{}]
+
+          role == :controlled and use_candidate == false ->
+            [%ICEControlling{tiebreaker: tiebreaker + 1}]
+
+          role == :controlling ->
+            [%ICEControlled{tiebreaker: tiebreaker - 1}]
+        end
+
+      attrs =
+        [
+          %Username{value: "#{remote_ufrag}:#{local_ufrag}"},
+          %Priority{priority: 1234}
+        ] ++ ice_attrs
+
+      Message.new(%Type{class: :request, method: :binding}, attrs)
+      |> Message.with_integrity(remote_pwd)
+      |> Message.with_fingerprint()
+    end
+  end
+end


### PR DESCRIPTION
When moving to the failed or completed state, we have been clearing the whole state, in particular we have been removing unused candidate pairs, local candidates and sockets.

Such approach makes it hard to debug connectivity issues, as when we moved to the failed state, we cannot inspect checklist pairs, requests sent and responses received (tracking requests and responses is not implemented yet).

After these changes, when the PC moves to the failed state, one will be able to get ICE transport stats and try to analyze what went wrong.