### PR TITLE
Add stats for pair's requests

### DIFF
--- a/lib/ex_ice/candidate_pair.ex
+++ b/lib/ex_ice/candidate_pair.ex
@@ -12,7 +12,14 @@ defmodule ExICE.CandidatePair do
           priority: non_neg_integer(),
           remote_cand_id: integer(),
           state: state(),
-          valid?: boolean()
+          valid?: boolean(),
+          last_seen: integer(),
+          # stats
+          requests_received: non_neg_integer(),
+          requests_sent: non_neg_integer(),
+          responses_received: non_neg_integer(),
+          non_symmetric_responses_received: non_neg_integer(),
+          responses_sent: non_neg_integer()
         }
 
   @enforce_keys [:id, :local_cand_id, :remote_cand_id, :priority]
@@ -20,6 +27,12 @@ defmodule ExICE.CandidatePair do
               [
                 nominated?: false,
                 state: :frozen,
-                valid?: false
+                valid?: false,
+                last_seen: nil,
+                requests_received: 0,
+                requests_sent: 0,
+                responses_received: 0,
+                non_symmetric_responses_received: 0,
+                responses_sent: 0
               ]
 end

--- a/lib/ex_ice/priv/candidate_pair.ex
+++ b/lib/ex_ice/priv/candidate_pair.ex
@@ -21,7 +21,12 @@ defmodule ExICE.Priv.CandidatePair do
           succeeded_pair_id: integer() | nil,
           discovered_pair_id: integer() | nil,
           keepalive_timer: reference() | nil,
-          last_seen: integer()
+          last_seen: integer(),
+          requests_received: non_neg_integer(),
+          requests_sent: non_neg_integer(),
+          responses_received: non_neg_integer(),
+          non_symmetric_responses_received: non_neg_integer(),
+          responses_sent: non_neg_integer()
         }
 
   @enforce_keys [:id, :local_cand_id, :remote_cand_id, :priority]
@@ -36,7 +41,12 @@ defmodule ExICE.Priv.CandidatePair do
                 keepalive_timer: nil,
                 # Time when this pair has received some data
                 # or sent conn check.
-                last_seen: nil
+                last_seen: nil,
+                requests_received: 0,
+                requests_sent: 0,
+                responses_received: 0,
+                non_symmetric_responses_received: 0,
+                responses_sent: 0
               ]
 
   @doc false
@@ -101,7 +111,13 @@ defmodule ExICE.Priv.CandidatePair do
       priority: pair.priority,
       remote_cand_id: pair.remote_cand_id,
       state: pair.state,
-      valid?: pair.valid?
+      valid?: pair.valid?,
+      last_seen: pair.last_seen,
+      requests_received: pair.requests_received,
+      requests_sent: pair.requests_sent,
+      responses_received: pair.responses_received,
+      non_symmetric_responses_received: pair.non_symmetric_responses_received,
+      responses_sent: pair.responses_sent
     }
   end
 end

--- a/lib/ex_ice/priv/conn_check_handler/controlling.ex
+++ b/lib/ex_ice/priv/conn_check_handler/controlling.ex
@@ -36,32 +36,59 @@ defmodule ExICE.Priv.ConnCheckHandler.Controlling do
 
       nil when ice_agent.state in [:new, :checking, :connected] ->
         Logger.debug("Adding new candidate pair: #{inspect(pair)}")
+        pair = %CandidatePair{pair | requests_received: 1}
         checklist = Map.put(ice_agent.checklist, pair.id, pair)
         ice_agent = %ICEAgent{ice_agent | checklist: checklist}
         ICEAgent.send_binding_success_response(ice_agent, pair, msg)
 
       %CandidatePair{} = checklist_pair ->
         cond do
-          checklist_pair.state == :failed and ice_agent.state in [:failed, :completed] ->
-            # update last seen so we can observe that something is received but don't reply
-            # as we are in the failed state
-            checklist_pair = %CandidatePair{checklist_pair | last_seen: pair.last_seen}
-            put_in(ice_agent.checklist[checklist_pair.id], checklist_pair)
+          ice_agent.state == :failed ->
+            r_pair = resolve_pair(ice_agent, checklist_pair)
 
-          checklist_pair.state == :failed ->
-            checklist_pair = %CandidatePair{
-              checklist_pair
-              | state: :waiting,
-                last_seen: pair.last_seen
+            r_pair = %CandidatePair{
+              r_pair
+              | last_seen: pair.last_seen,
+                requests_received: r_pair.requests_received + 1
             }
 
-            ice_agent = put_in(ice_agent.checklist[checklist_pair.id], checklist_pair)
-            ICEAgent.send_binding_success_response(ice_agent, checklist_pair, msg)
+            put_in(ice_agent.checklist[r_pair.id], r_pair)
+
+          checklist_pair.state == :failed and ice_agent.state == :completed ->
+            r_pair = resolve_pair(ice_agent, checklist_pair)
+
+            r_pair = %CandidatePair{
+              r_pair
+              | last_seen: pair.last_seen,
+                requests_received: r_pair.requests_received + 1
+            }
+
+            put_in(ice_agent.checklist[r_pair.id], r_pair)
+
+          checklist_pair.state == :failed ->
+            r_pair = resolve_pair(ice_agent, checklist_pair)
+
+            r_pair = %CandidatePair{
+              r_pair
+              | state: :waiting,
+                last_seen: pair.last_seen,
+                requests_received: r_pair.requests_received + 1
+            }
+
+            ice_agent = put_in(ice_agent.checklist[r_pair.id], r_pair)
+            ICEAgent.send_binding_success_response(ice_agent, r_pair, msg)
 
           true ->
-            checklist_pair = %CandidatePair{checklist_pair | last_seen: pair.last_seen}
-            ice_agent = put_in(ice_agent.checklist[checklist_pair.id], checklist_pair)
-            ICEAgent.send_binding_success_response(ice_agent, checklist_pair, msg)
+            r_pair = resolve_pair(ice_agent, checklist_pair)
+
+            r_pair = %CandidatePair{
+              r_pair
+              | last_seen: pair.last_seen,
+                requests_received: r_pair.requests_received + 1
+            }
+
+            ice_agent = put_in(ice_agent.checklist[r_pair.id], r_pair)
+            ICEAgent.send_binding_success_response(ice_agent, r_pair, msg)
         end
     end
   end
@@ -85,5 +112,9 @@ defmodule ExICE.Priv.ConnCheckHandler.Controlling do
 
     ice_agent = %ICEAgent{ice_agent | nominating?: {false, nil}, selected_pair_id: pair.id}
     ICEAgent.change_connection_state(ice_agent, :completed)
+  end
+
+  defp resolve_pair(ice_agent, pair) do
+    (pair.discovered_pair_id && Map.fetch!(ice_agent.checklist, pair.discovered_pair_id)) || pair
   end
 end

--- a/test/priv/conn_check_handler/controlled_test.exs
+++ b/test/priv/conn_check_handler/controlled_test.exs
@@ -71,20 +71,24 @@ defmodule ExICE.Priv.ConnCheckHandler.ControlledTest do
       new_ice_agent = Controlled.handle_conn_check_request(ice_agent, pair, req, nil)
 
       # assert a response has not been sent, and pair and agent are still in state failed
-      pair = Map.fetch!(new_ice_agent.checklist, pair_id)
+      new_pair = Map.fetch!(new_ice_agent.checklist, pair_id)
       assert Transport.Mock.recv(socket) == nil
       assert new_ice_agent.state == :failed
-      assert pair.state == :failed
+      assert new_pair.state == :failed
+      assert new_pair.requests_received == pair.requests_received + 1
+      assert new_pair.responses_sent == pair.responses_sent
 
       # the same when with UseCandidate flag
       new_ice_agent =
         Controlled.handle_conn_check_request(ice_agent, pair, use_c_req, %UseCandidate{})
 
       # assert a response has not been sent, and pair and agent are still in state failed
-      pair = Map.fetch!(new_ice_agent.checklist, pair_id)
+      new_pair = Map.fetch!(new_ice_agent.checklist, pair_id)
       assert Transport.Mock.recv(socket) == nil
       assert new_ice_agent.state == :failed
-      assert pair.state == :failed
+      assert new_pair.state == :failed
+      assert new_pair.requests_received == pair.requests_received + 1
+      assert new_pair.responses_sent == pair.responses_sent
     end
 
     test "on failed pair in completed state", %{
@@ -109,20 +113,24 @@ defmodule ExICE.Priv.ConnCheckHandler.ControlledTest do
       new_ice_agent = Controlled.handle_conn_check_request(ice_agent, pair1, req, nil)
 
       # assert a response has not been sent, pair_id1 is still in state failed and agent is still in state completed
-      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      new_pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
       assert Transport.Mock.recv(socket) == nil
       assert new_ice_agent.state == :completed
-      assert pair1.state == :failed
+      assert new_pair1.state == :failed
+      assert new_pair1.requests_received == pair1.requests_received + 1
+      assert new_pair1.responses_sent == pair1.responses_sent
 
       # the same when with UseCandidate flag
       new_ice_agent =
         Controlled.handle_conn_check_request(ice_agent, pair1, use_c_req, %UseCandidate{})
 
       # assert a response has not been sent, pair_id1 is still in state failed and agent is still in state completed
-      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      new_pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
       assert Transport.Mock.recv(socket) == nil
       assert new_ice_agent.state == :completed
-      assert pair1.state == :failed
+      assert new_pair1.state == :failed
+      assert new_pair1.requests_received == pair1.requests_received + 1
+      assert new_pair1.responses_sent == pair1.responses_sent
     end
 
     test "on failed pair in connected state", %{
@@ -146,22 +154,26 @@ defmodule ExICE.Priv.ConnCheckHandler.ControlledTest do
       new_ice_agent = Controlled.handle_conn_check_request(ice_agent, pair1, req, nil)
 
       # assert a response has been sent, pair_id1 is waiting and agent is connected
-      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      new_pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
       assert Transport.Mock.recv(socket) != nil
       assert new_ice_agent.state == :connected
-      assert pair1.state == :waiting
-      assert pair1.nominate? == false
+      assert new_pair1.state == :waiting
+      assert new_pair1.nominate? == false
+      assert new_pair1.requests_received == pair1.requests_received + 1
+      assert new_pair1.responses_sent == pair1.responses_sent + 1
 
       # the same when with UseCandidate flag
       new_ice_agent =
         Controlled.handle_conn_check_request(ice_agent, pair1, use_c_req, %UseCandidate{})
 
       # assert a response has been sent, pair is waiting and agent is connected
-      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      new_pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
       assert Transport.Mock.recv(socket) != nil
       assert new_ice_agent.state == :connected
-      assert pair1.state == :waiting
-      assert pair1.nominate? == true
+      assert new_pair1.state == :waiting
+      assert new_pair1.nominate? == true
+      assert new_pair1.requests_received == pair1.requests_received + 1
+      assert new_pair1.responses_sent == pair1.responses_sent + 1
     end
 
     test "on selected pair in completed state", %{
@@ -188,24 +200,28 @@ defmodule ExICE.Priv.ConnCheckHandler.ControlledTest do
       new_ice_agent = Controlled.handle_conn_check_request(ice_agent, pair1, req, nil)
 
       # assert a response has been sent, pair_id1 is still in state succeeded and agent is still in state completed
-      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      new_pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
       assert Transport.Mock.recv(socket) != nil
       assert new_ice_agent.state == :completed
       assert new_ice_agent.selected_pair_id == pair_id1
-      assert pair1.state == :succeeded
-      assert pair1.valid? == true
+      assert new_pair1.state == :succeeded
+      assert new_pair1.valid? == true
+      assert new_pair1.requests_received == pair1.requests_received + 1
+      assert new_pair1.responses_sent == pair1.responses_sent + 1
 
       # the same when with UseCandidate flag
       new_ice_agent =
         Controlled.handle_conn_check_request(ice_agent, pair1, use_c_req, %UseCandidate{})
 
       # assert a response has not been sent, pair_id1 is still in state failed and agent is still in state completed
-      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      new_pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
       assert Transport.Mock.recv(socket) != nil
       assert new_ice_agent.state == :completed
       assert new_ice_agent.selected_pair_id == pair_id1
-      assert pair1.state == :succeeded
-      assert pair1.valid? == true
+      assert new_pair1.state == :succeeded
+      assert new_pair1.valid? == true
+      assert new_pair1.requests_received == pair1.requests_received + 1
+      assert new_pair1.responses_sent == pair1.responses_sent + 1
     end
 
     test "on succeeded pair in connected state", %{
@@ -230,24 +246,28 @@ defmodule ExICE.Priv.ConnCheckHandler.ControlledTest do
       new_ice_agent = Controlled.handle_conn_check_request(ice_agent, pair1, req, nil)
 
       # assert a response has been sent, pair_id1 is still in state succeeded and agent is still in state connected
-      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      new_pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
       assert Transport.Mock.recv(socket) != nil
       assert new_ice_agent.state == :connected
       assert new_ice_agent.selected_pair_id == nil
-      assert pair1.state == :succeeded
-      assert pair1.valid? == true
+      assert new_pair1.state == :succeeded
+      assert new_pair1.valid? == true
+      assert new_pair1.requests_received == pair1.requests_received + 1
+      assert new_pair1.responses_sent == pair1.responses_sent + 1
 
       # the same when with UseCandidate flag
       new_ice_agent =
         Controlled.handle_conn_check_request(ice_agent, pair1, use_c_req, %UseCandidate{})
 
       # assert a response has been sent, pair_id1 is still in state succeeded, agent is still in state connected but there is also selected pair
-      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      new_pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
       assert Transport.Mock.recv(socket) != nil
       assert new_ice_agent.state == :connected
       assert new_ice_agent.selected_pair_id == pair_id1
-      assert pair1.state == :succeeded
-      assert pair1.valid? == true
+      assert new_pair1.state == :succeeded
+      assert new_pair1.valid? == true
+      assert new_pair1.requests_received == pair1.requests_received + 1
+      assert new_pair1.responses_sent == pair1.responses_sent + 1
     end
 
     test "on succeeded pair that has higher prio in connected state", %{
@@ -278,12 +298,14 @@ defmodule ExICE.Priv.ConnCheckHandler.ControlledTest do
         Controlled.handle_conn_check_request(ice_agent, pair1, use_c_req, %UseCandidate{})
 
       # assert a response has been sent, and pair_id1 is a new selected pair
-      pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
+      new_pair1 = Map.fetch!(new_ice_agent.checklist, pair_id1)
       assert Transport.Mock.recv(socket) != nil
       assert new_ice_agent.state == :connected
       assert new_ice_agent.selected_pair_id == pair_id1
-      assert pair1.state == :succeeded
-      assert pair1.valid? == true
+      assert new_pair1.state == :succeeded
+      assert new_pair1.valid? == true
+      assert new_pair1.requests_received == pair1.requests_received + 1
+      assert new_pair1.responses_sent == pair1.responses_sent + 1
     end
 
     test "on unknown pair in connected state", %{
@@ -311,24 +333,28 @@ defmodule ExICE.Priv.ConnCheckHandler.ControlledTest do
       new_ice_agent = Controlled.handle_conn_check_request(ice_agent, pair2, req, nil)
 
       # assert a response has been sent, and we have a new pair in the checklist
-      pair2 = Map.fetch!(new_ice_agent.checklist, pair_id2)
+      new_pair2 = Map.fetch!(new_ice_agent.checklist, pair_id2)
       assert Transport.Mock.recv(socket) != nil
       assert new_ice_agent.state == :connected
-      assert pair2.state == :waiting
-      assert pair2.valid? == false
-      assert pair2.nominate? == false
+      assert new_pair2.state == :waiting
+      assert new_pair2.valid? == false
+      assert new_pair2.nominate? == false
+      assert new_pair2.requests_received == pair2.requests_received + 1
+      assert new_pair2.responses_sent == pair2.responses_sent + 1
 
       # the same with UseCandidate flag
       new_ice_agent =
         Controlled.handle_conn_check_request(ice_agent, pair2, use_c_req, %UseCandidate{})
 
       # assert a response has been sent, and we have a new pair in the checklist
-      pair2 = Map.fetch!(new_ice_agent.checklist, pair_id2)
+      new_pair2 = Map.fetch!(new_ice_agent.checklist, pair_id2)
       assert Transport.Mock.recv(socket) != nil
       assert new_ice_agent.state == :connected
-      assert pair2.state == :waiting
-      assert pair2.valid? == false
-      assert pair2.nominate? == true
+      assert new_pair2.state == :waiting
+      assert new_pair2.valid? == false
+      assert new_pair2.nominate? == true
+      assert new_pair2.requests_received == pair2.requests_received + 1
+      assert new_pair2.responses_sent == pair2.responses_sent + 1
     end
 
     defp binding_request(


### PR DESCRIPTION
Stats based on: https://www.w3.org/TR/webrtc-stats/#candidatepair-dict*

`non_symmetric_responses_received` is a custom stat to make it easier to detect non-symmetric responses, which may happen when there is SNAT on the path. 