### PR TITLE
Fix role conflict resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ as WebRTC multiplexes traffic on a single socket but PRs are welcomed
 ```elixir
 def deps do
   [
-    {:ex_ice, "~> 0.10.0"}
+    {:ex_ice, "~> 0.10.1"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExICE.MixProject do
   use Mix.Project
 
-  @version "0.10.0"
+  @version "0.10.1"
   @source_url "https://github.com/elixir-webrtc/ex_ice"
 
   def project do


### PR DESCRIPTION
When receiving role conflict error response, an agent MUST change its role to the opposite to the one included in binding request. This means that the following scenario should only result in one role switch:

1. generate binding request 1 with role X
2. generate binding request 2 with role X
3. receive 487 error response for req 1
4. change role to Y 
5. receive 487 error response for req 2
6. should change role to Y (as in req 2 there was role X) but because agent is already in role Y we can do nothing