### PR TITLE
Fix MatchError crash when TURN socket closes during allocation refresh

### DIFF
--- a/lib/ex_ice/priv/ice_agent.ex
+++ b/lib/ex_ice/priv/ice_agent.ex
@@ -963,6 +963,9 @@ defmodule ExICE.Priv.ICEAgent do
             update_gathering_state(ice_agent)
         end
 
+      {nil, %{client: %{state: :error}}} ->
+        ice_agent
+
       {nil, cand} ->
         case ExTURN.Client.handle_message(cand.client, msg) do
           {:ok, client} ->

--- a/lib/ex_ice/priv/ice_agent.ex
+++ b/lib/ex_ice/priv/ice_agent.ex
@@ -944,8 +944,19 @@ defmodule ExICE.Priv.ICEAgent do
 
           {:send, dst, data, client} ->
             tr = %{tr | client: client}
-            :ok = ice_agent.transport_module.send(tr.socket, dst, data)
-            put_in(ice_agent.gathering_transactions[tr_id], tr)
+
+            case ice_agent.transport_module.send(tr.socket, dst, data) do
+              :ok ->
+                put_in(ice_agent.gathering_transactions[tr_id], tr)
+
+              {:error, reason} ->
+                Logger.debug(
+                  "Failed to send TURN message: #{inspect(reason)}. Closing transaction."
+                )
+
+                {_, ice_agent} = pop_in(ice_agent.gathering_transactions[tr_id])
+                update_gathering_state(ice_agent)
+            end
 
           {:error, _reason, _client} ->
             {_, ice_agent} = pop_in(ice_agent.gathering_transactions[tr_id])
@@ -962,8 +973,17 @@ defmodule ExICE.Priv.ICEAgent do
             cand = %{cand | client: client}
             ice_agent = put_in(ice_agent.local_cands[cand.base.id], cand)
             # we can't use do_send here as it will try to create permission for the turn address
-            :ok = ice_agent.transport_module.send(cand.base.socket, dst, data)
-            ice_agent
+            case ice_agent.transport_module.send(cand.base.socket, dst, data) do
+              :ok ->
+                ice_agent
+
+              {:error, reason} ->
+                Logger.debug(
+                  "Failed to send TURN message: #{inspect(reason)}. Closing candidate."
+                )
+
+                close_candidate(ice_agent, cand)
+            end
 
           {:error, _reason, client} ->
             Logger.debug("""


### PR DESCRIPTION
Fixes crash:
```
** (MatchError) no match of right hand side value: {:error, :closed}
    (ex_ice 0.14.0) lib/ex_ice/priv/ice_agent.ex:947
```

When TURN sockets close unexpectedly during allocation refresh, `transport_module.send/3` returns `{:error, :closed}`, causing the above MatchError that terminates WebRTC streams.

This PR wraps the send calls in case statements to handle errors gracefully by closing the transaction/candidate and cleaning up state.