### PR TITLE
fix: guard against KeyError in handle_keepalive_response

### DIFF
--- a/lib/ex_ice/priv/ice_agent.ex
+++ b/lib/ex_ice/priv/ice_agent.ex
@@ -1999,7 +1999,13 @@ defmodule ExICE.Priv.ICEAgent do
          %Message{type: %Type{class: :success_response}} = msg
        ) do
     {pair_id, ice_agent} = pop_in(ice_agent.keepalives[msg.transaction_id])
-    pair = Map.fetch!(ice_agent.checklist, pair_id)
+
+    case Map.get(ice_agent.checklist, pair_id) do
+      nil ->
+        Logger.debug("Keepalive success response for pruned pair #{inspect(pair_id)}, ignoring")
+        ice_agent
+
+      pair ->
 
     with true <- symmetric?(ice_agent, local_cand.base.socket, {src_ip, src_port}, pair),
          :ok <- authenticate_msg(msg, ice_agent.remote_pwd) do
@@ -2043,6 +2049,7 @@ defmodule ExICE.Priv.ICEAgent do
         pair = %CandidatePair{pair | responses_received: pair.responses_received + 1}
         put_in(ice_agent.checklist[pair.id], pair)
     end
+    end
   end
 
   defp handle_keepalive_response(
@@ -2053,18 +2060,25 @@ defmodule ExICE.Priv.ICEAgent do
          %Message{type: %Type{class: :error_response}} = msg
        ) do
     {pair_id, ice_agent} = pop_in(ice_agent.keepalives[msg.transaction_id])
-    pair = Map.fetch!(ice_agent.checklist, pair_id)
-    pair = %CandidatePair{pair | responses_received: pair.responses_received + 1}
-    ice_agent = put_in(ice_agent.checklist[pair.id], pair)
 
-    Logger.debug("""
-    Received keepalive error response from #{inspect({src_ip, src_port})}, \
-    on: #{inspect({local_cand.base.base_address, local_cand.base.base_port})}. \
-    pair: #{pair_info(ice_agent, pair)} \
-    Not refreshing last_seen time. \
-    """)
+    case Map.get(ice_agent.checklist, pair_id) do
+      nil ->
+        Logger.debug("Keepalive error response for pruned pair #{inspect(pair_id)}, ignoring")
+        ice_agent
 
-    ice_agent
+      pair ->
+        pair = %CandidatePair{pair | responses_received: pair.responses_received + 1}
+        ice_agent = put_in(ice_agent.checklist[pair.id], pair)
+
+        Logger.debug("""
+        Received keepalive error response from #{inspect({src_ip, src_port})}, \
+        on: #{inspect({local_cand.base.base_address, local_cand.base.base_port})}. \
+        pair: #{pair_info(ice_agent, pair)} \
+        Not refreshing last_seen time. \
+        """)
+
+        ice_agent
+    end
   end
 
   # Adds valid pair according to sec 7.2.5.3.2


### PR DESCRIPTION
## Problem

`handle_keepalive_response/5` uses `Map.fetch!(ice_agent.checklist, pair_id)` to retrieve a candidate pair. If a keepalive response arrives after the pair has been pruned from the checklist (e.g., due to network switch, ICE restart, or state transition), this crashes with a `KeyError`.

This was reported in #65 and partially addressed by #69 (which stopped clearing the checklist on state transitions), but the `Map.fetch!` calls remain in both the success and error response handlers, so the race condition can still trigger.

Issue #80 reports a similar crash pattern in a different code path.

## Fix

Replace `Map.fetch!` with `Map.get` + `case` guard in both `handle_keepalive_response` clauses:
- **Success response** (line 2002): If pair is `nil`, log and return `ice_agent` unchanged
- **Error response** (line 2056): Same guard