### PR TITLE
Exclude Base64 padding from ICEAgent credentials

### DIFF
--- a/lib/ex_ice/priv/ice_agent.ex
+++ b/lib/ex_ice/priv/ice_agent.ex
@@ -2675,8 +2675,8 @@ defmodule ExICE.Priv.ICEAgent do
   end
 
   defp generate_credentials() do
-    ufrag = :crypto.strong_rand_bytes(3) |> Base.encode64()
-    pwd = :crypto.strong_rand_bytes(16) |> Base.encode64()
+    ufrag = :crypto.strong_rand_bytes(3) |> Base.encode64(padding: false)
+    pwd = :crypto.strong_rand_bytes(16) |> Base.encode64(padding: false)
     {ufrag, pwd}
   end
 

--- a/test/priv/ice_agent_test.exs
+++ b/test/priv/ice_agent_test.exs
@@ -2908,6 +2908,23 @@ defmodule ExICE.Priv.ICEAgentTest do
     assert <<_channel_number::16, _len::16, "somedata">> = packet
   end
 
+  describe "generate_credentials/0" do
+    test "generates credentials without padding" do
+      ice_agent =
+        ICEAgent.new(
+          controlling_process: self(),
+          role: :controlling,
+          if_discovery_module: IfDiscovery.MockSingle,
+          transport_module: Transport.Mock
+        )
+
+      refute String.contains?(ice_agent.local_ufrag, "=")
+      refute String.contains?(ice_agent.local_pwd, "=")
+      assert byte_size(ice_agent.local_ufrag) == 4
+      assert byte_size(ice_agent.local_pwd) == 22
+    end
+  end
+
   defp connect(ice_agent) do
     [socket] = ice_agent.sockets
     [remote_cand] = Map.values(ice_agent.remote_cands)


### PR DESCRIPTION
We use `ex_ice` dependency as part of WHEP -> GStreamer pipeline. On the GStreamer side, `whepclientsrc` is used to get media from Membrane pipeline and it requires ICE credentials in Base64 format without padding. This PR is part of fix for our WHEP -> GStreamer implementation (another part is in ex_webrtc, which I am currently working on), let me know if this changes are feasible to be in `ex_ice` lib