### PR TITLE
Generate ICE credentials without base64 padding

### DIFF
--- a/lib/ex_ice/priv/ice_agent.ex
+++ b/lib/ex_ice/priv/ice_agent.ex
@@ -2700,8 +2700,11 @@ defmodule ExICE.Priv.ICEAgent do
   end
 
   defp generate_credentials() do
-    ufrag = :crypto.strong_rand_bytes(3) |> Base.encode64()
-    pwd = :crypto.strong_rand_bytes(16) |> Base.encode64()
+    # ice-char does not include '=' (RFC 8839 sec. 5.4, RFC 5245 sec. 15.4),
+    # so credentials must not contain base64 padding. Strict parsers
+    # (e.g. GStreamer's webrtcbin since 1.28) reject SDP with padded ice-pwd.
+    ufrag = :crypto.strong_rand_bytes(3) |> Base.encode64(padding: false)
+    pwd = :crypto.strong_rand_bytes(16) |> Base.encode64(padding: false)
     {ufrag, pwd}
   end
 

--- a/test/priv/ice_agent_test.exs
+++ b/test/priv/ice_agent_test.exs
@@ -82,6 +82,24 @@ defmodule ExICE.Priv.ICEAgentTest do
   @remote_cand ExICE.Candidate.new(:host, address: {192, 168, 0, 2}, port: 8445, priority: 123)
   @remote_cand2 ExICE.Candidate.new(:host, address: {192, 168, 0, 3}, port: 8445, priority: 122)
 
+  test "generates ice-char compliant local credentials" do
+    # ice-char = ALPHA / DIGIT / "+" / "/" (RFC 8839 sec. 5.4) — in particular
+    # no base64 '=' padding, which strict SDP parsers reject.
+    ice_agent =
+      ICEAgent.new(
+        controlling_process: self(),
+        role: :controlling,
+        if_discovery_module: IfDiscovery.MockSingle,
+        transport_module: Transport.Mock
+      )
+
+    assert ice_agent.local_ufrag =~ ~r|^[A-Za-z0-9+/]+$|
+    assert ice_agent.local_pwd =~ ~r|^[A-Za-z0-9+/]+$|
+    # RFC 8839: ufrag is 4..256 ice-chars, pwd is 22..256 ice-chars
+    assert byte_size(ice_agent.local_ufrag) >= 4
+    assert byte_size(ice_agent.local_pwd) >= 22
+  end
+
   describe "unmarshal_remote_candidate/1" do
     test "with correct candidate" do
       cand = "1 1 UDP 1686052863 127.0.0.1 57940 typ srflx raddr 0.0.0.0 rport 0"


### PR DESCRIPTION
EDIT: Appears this is a duplicate of https://github.com/elixir-webrtc/ex_ice/pull/98 . Can we merge one of these two PRs? 

`ice-char` (RFC 8839 §5.4 / RFC 5245 §15.4) is `ALPHA / DIGIT / "+" / "/"` — base64's `=` padding is not legal in `ice-ufrag`/`ice-pwd`. The 16-byte pwd encoded with padding always ends in `==`; strict parsers reject the SDP outright (GStreamer's webrtcbin validates ICE attributes since 1.28), and receivers can't work around it: stripping `=` before parsing desyncs the pwd used for STUN message integrity, so connectivity checks never authenticate and ICE sits in `checking`.

**Fix:** encode with `padding: false`. Entropy is unchanged (padding carries no information), the unpadded alphabet is a strict subset of what every peer already accepts (so no compatibility flag is warranted), and lengths still meet the RFC minimums exactly — ufrag 4 chars (3 bytes never produced padding anyway; the change there is defensive), pwd 22 chars.

**Prior art:** other ICE implementations avoid the problem by construction — they sample random characters directly from a legal alphabet instead of encoding random bytes: [pion/ice](https://github.com/pion/ice/blob/master/rand.go) draws 16-char ufrags and 32-char pwds from a letters-only set (and quotes the ice-char grammar in its source), [libnice](https://gitlab.freedesktop.org/libnice/libnice/-/blob/master/random/random.c) samples from exactly `A-Za-z0-9+/`, and [aioice](https://github.com/aiortc/aioice/blob/main/src/aioice/utils.py) from letters+digits. If you'd prefer that construction-level approach (or longer-than-minimum credentials like pion's) over the minimal `padding: false` diff, happy to rework the PR that way.

Added a regression test asserting generated credentials match the ice-char grammar and RFC minimum lengths. Full suite passes locally (133 tests, 0 failures).